### PR TITLE
Add GPU support for model and flows

### DIFF
--- a/nf/flows.py
+++ b/nf/flows.py
@@ -175,8 +175,8 @@ class MAF(nn.Module):
         init.uniform_(self.initial_param, -math.sqrt(0.5), math.sqrt(0.5))
 
     def forward(self, x):
-        z = torch.zeros_like(x).to(x.device)
-        log_det = torch.zeros(z.shape[0]).to(x.device)
+        z = torch.zeros_like(x, device=x.device)
+        log_det = torch.zeros(z.shape[0], device=x.device)
         for i in range(self.dim):
             if i == 0:
                 mu, alpha = self.initial_param[0], self.initial_param[1]
@@ -188,8 +188,8 @@ class MAF(nn.Module):
         return z.flip(dims=(1,)), log_det
 
     def inverse(self, z):
-        x = torch.zeros_like(z).to(z.device)
-        log_det = torch.zeros(z.shape[0]).to(z.device)
+        x = torch.zeros_like(z, device=z.device)
+        log_det = torch.zeros(z.shape[0], device=z.device)
         z = z.flip(dims=(1,))
         for i in range(self.dim):
             if i == 0:
@@ -283,8 +283,8 @@ class NSF_AR(nn.Module):
         init.uniform_(self.init_param, - 1 / 2, 1 / 2)
 
     def forward(self, x):
-        z = torch.zeros_like(x)
-        log_det = torch.zeros(z.shape[0]).to(x.device)
+        z = torch.zeros_like(x, device=x.device)
+        log_det = torch.zeros(z.shape[0], device=x.device)
         for i in range(self.dim):
             if i == 0:
                 init_param = self.init_param.expand(x.shape[0], 3 * self.K - 1)
@@ -301,8 +301,8 @@ class NSF_AR(nn.Module):
         return z, log_det
 
     def inverse(self, z):
-        x = torch.zeros_like(z).to(z.device)
-        log_det = torch.zeros(x.shape[0]).to(z.device)
+        x = torch.zeros_like(z, device=z.device)
+        log_det = torch.zeros(x.shape[0], device=z.device)
         for i in range(self.dim):
             if i == 0:
                 init_param = self.init_param.expand(x.shape[0], 3 * self.K - 1)
@@ -334,7 +334,7 @@ class NSF_CL(nn.Module):
         self.f2 = base_network(dim // 2, (3 * K - 1) * dim // 2, hidden_dim)
 
     def forward(self, x):
-        log_det = torch.zeros(x.shape[0]).to(x.device)
+        log_det = torch.zeros(x.shape[0], device=x.device)
         lower, upper = x[:, :self.dim // 2], x[:, self.dim // 2:]
         out = self.f1(lower).reshape(-1, self.dim // 2, 3 * self.K - 1)
         W, H, D = torch.split(out, self.K, dim = 2)
@@ -355,7 +355,7 @@ class NSF_CL(nn.Module):
         return torch.cat([lower, upper], dim = 1), log_det
 
     def inverse(self, z):
-        log_det = torch.zeros(z.shape[0]).to(z.device)
+        log_det = torch.zeros(z.shape[0], device=z.device)
         lower, upper = z[:, :self.dim // 2], z[:, self.dim // 2:]
         out = self.f2(upper).reshape(-1, self.dim // 2, 3 * self.K - 1)
         W, H, D = torch.split(out, self.K, dim = 2)

--- a/nf/flows.py
+++ b/nf/flows.py
@@ -175,8 +175,8 @@ class MAF(nn.Module):
         init.uniform_(self.initial_param, -math.sqrt(0.5), math.sqrt(0.5))
 
     def forward(self, x):
-        z = torch.zeros_like(x)
-        log_det = torch.zeros(z.shape[0])
+        z = torch.zeros_like(x).to(x.device)
+        log_det = torch.zeros(z.shape[0]).to(x.device)
         for i in range(self.dim):
             if i == 0:
                 mu, alpha = self.initial_param[0], self.initial_param[1]
@@ -188,8 +188,8 @@ class MAF(nn.Module):
         return z.flip(dims=(1,)), log_det
 
     def inverse(self, z):
-        x = torch.zeros_like(z)
-        log_det = torch.zeros(z.shape[0])
+        x = torch.zeros_like(z).to(z.device)
+        log_det = torch.zeros(z.shape[0]).to(z.device)
         z = z.flip(dims=(1,))
         for i in range(self.dim):
             if i == 0:
@@ -284,7 +284,7 @@ class NSF_AR(nn.Module):
 
     def forward(self, x):
         z = torch.zeros_like(x)
-        log_det = torch.zeros(z.shape[0])
+        log_det = torch.zeros(z.shape[0]).to(x.device)
         for i in range(self.dim):
             if i == 0:
                 init_param = self.init_param.expand(x.shape[0], 3 * self.K - 1)
@@ -301,8 +301,8 @@ class NSF_AR(nn.Module):
         return z, log_det
 
     def inverse(self, z):
-        x = torch.zeros_like(z)
-        log_det = torch.zeros(x.shape[0])
+        x = torch.zeros_like(z).to(z.device)
+        log_det = torch.zeros(x.shape[0]).to(z.device)
         for i in range(self.dim):
             if i == 0:
                 init_param = self.init_param.expand(x.shape[0], 3 * self.K - 1)
@@ -334,7 +334,7 @@ class NSF_CL(nn.Module):
         self.f2 = base_network(dim // 2, (3 * K - 1) * dim // 2, hidden_dim)
 
     def forward(self, x):
-        log_det = torch.zeros(x.shape[0])
+        log_det = torch.zeros(x.shape[0]).to(x.device)
         lower, upper = x[:, :self.dim // 2], x[:, self.dim // 2:]
         out = self.f1(lower).reshape(-1, self.dim // 2, 3 * self.K - 1)
         W, H, D = torch.split(out, self.K, dim = 2)
@@ -355,7 +355,7 @@ class NSF_CL(nn.Module):
         return torch.cat([lower, upper], dim = 1), log_det
 
     def inverse(self, z):
-        log_det = torch.zeros(z.shape[0])
+        log_det = torch.zeros(z.shape[0]).to(z.device)
         lower, upper = z[:, :self.dim // 2], z[:, self.dim // 2:]
         out = self.f2(upper).reshape(-1, self.dim // 2, 3 * self.K - 1)
         W, H, D = torch.split(out, self.K, dim = 2)

--- a/nf/models.py
+++ b/nf/models.py
@@ -29,5 +29,4 @@ class NormalizingFlowModel(nn.Module):
     def sample(self, n_samples):
         z = self.prior.sample((n_samples,))
         x, _ = self.inverse(z)
-        return x.to('cpu')
-
+        return x

--- a/nf/models.py
+++ b/nf/models.py
@@ -3,7 +3,6 @@ import torch.nn as nn
 
 
 class NormalizingFlowModel(nn.Module):
-
     def __init__(self, prior, flows):
         super().__init__()
         self.prior = prior
@@ -11,7 +10,7 @@ class NormalizingFlowModel(nn.Module):
 
     def forward(self, x):
         m, _ = x.shape
-        log_det = torch.zeros(m)
+        log_det = torch.zeros(m).to(x.device)
         for flow in self.flows:
             x, ld = flow.forward(x)
             log_det += ld
@@ -20,7 +19,7 @@ class NormalizingFlowModel(nn.Module):
 
     def inverse(self, z):
         m, _ = z.shape
-        log_det = torch.zeros(m)
+        log_det = torch.zeros(m).to(z.device)
         for flow in self.flows[::-1]:
             z, ld = flow.inverse(z)
             log_det += ld
@@ -30,5 +29,5 @@ class NormalizingFlowModel(nn.Module):
     def sample(self, n_samples):
         z = self.prior.sample((n_samples,))
         x, _ = self.inverse(z)
-        return x
+        return x.to('cpu')
 

--- a/nf/models.py
+++ b/nf/models.py
@@ -10,7 +10,7 @@ class NormalizingFlowModel(nn.Module):
 
     def forward(self, x):
         m, _ = x.shape
-        log_det = torch.zeros(m).to(x.device)
+        log_det = torch.zeros(m, device=x.device)
         for flow in self.flows:
             x, ld = flow.forward(x)
             log_det += ld
@@ -19,7 +19,7 @@ class NormalizingFlowModel(nn.Module):
 
     def inverse(self, z):
         m, _ = z.shape
-        log_det = torch.zeros(m).to(z.device)
+        log_det = torch.zeros(m, device=z.device)
         for flow in self.flows[::-1]:
             z, ld = flow.inverse(z)
             log_det += ld

--- a/nf/models.py
+++ b/nf/models.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 
 
 class NormalizingFlowModel(nn.Module):
-    
+
     def __init__(self, prior, flows):
         super().__init__()
         self.prior = prior

--- a/nf/models.py
+++ b/nf/models.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 
 
 class NormalizingFlowModel(nn.Module):
+    
     def __init__(self, prior, flows):
         super().__init__()
         self.prior = prior


### PR DESCRIPTION
I added GPU support for all forward/inverse passes of the flows that support it and NormalizingFlowModel. The tensors are moved to the same device as the input tensor (so wherever x or z are). For now, the result of sampling will be moved to the CPU, since I expect that to most often be the use-case. Let me know if you have any other suggestions. 

To get it working, put your x, prior and model on the GPU:
```python
device = 'cuda' if torch.cuda.is_available() else 'cpu'
prior = MultivariateNormal(torch.zeros(1).to(device), torch.eye(1).to(device))
model = NormalizingFlowModel(prior, flows).to(device)
x = torch.Tensor(gen_data(args.n)).to(device)
```

From there on, it should work without any problems. 

I didn't change the examples, but can make them use GPU is possible as well. Let me know your preference. 